### PR TITLE
fix: save Treafik acme certs on disk

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
     volumes:
       - ./traefik/traefik.toml:/etc/traefik/traefik.toml
       - "/var/run/docker.sock:/var/run/docker.sock:ro"    
+      - ./traefik-acme:/etc/traefik/acme
     networks:
       - micado_net
 

--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -8,6 +8,9 @@
 [api]
   insecure = true
 
+[acme]
+  storage = "/etc/traefik/acme/acme.json"
+
 [providers.docker]
   endpoint = "unix:///var/run/docker.sock"
   exposedByDefault = false


### PR DESCRIPTION
This PR fixes the rate limiting on Let's Encrypt:
You can have 50 certificates for one domain name and up to 5 duplicate certificates. So it should never be a problem for our services. https://letsencrypt.org/docs/rate-limits/

The problem most certainly was that the redeployment was done without reusing the previous certificates: https://docs.traefik.io/v1.4/configuration/acme/
So I updated the Treafik config file and the docker-compose file so that the certificates are stored in the `./traefik-acme` folder where you deploy.

That way we can endlessly redeploy and migrate to a new server (by simply copying the folder).


I cannot test it here in local. So maybe you can test it @gioppoluca? Or should someone else test this?
(I've never used Treafik before.)